### PR TITLE
Redesign setting .rodata map values (still broken state)

### DIFF
--- a/libbpfgo.go
+++ b/libbpfgo.go
@@ -1917,3 +1917,19 @@ func BPFProgramTypeIsSupported(progType BPFProgType) (bool, error) {
 	}
 	return cSupported == 1, nil
 }
+
+func (m *BPFMap) IsInternal() bool {
+	return bool(C.bpf_map__is_internal(m.bpfMap))
+}
+
+// SetROData
+func (m *BPFMap) SetROData(data unsafe.Pointer, size uintptr) error {
+	if !m.IsInternal() {
+		return fmt.Errorf("cannot set rodata for non internal map")
+	}
+	errC := C.bpf_map__set_initial_value(m.bpfMap, data, C.ulong(size))
+	if errC != 0 {
+		return fmt.Errorf("uh oh: %w\n", syscall.Errno(-errC))
+	}
+	return nil
+}

--- a/selftest/global-variable/main.bpf.c
+++ b/selftest/global-variable/main.bpf.c
@@ -8,36 +8,8 @@
 #define asm_inline asm
 #endif
 
-struct {
-    __uint(type, BPF_MAP_TYPE_RINGBUF);
-    __uint(max_entries, 1 << 24);
-} events SEC(".maps");
-
-const volatile int foo SEC(".rodata") = 0;
-const volatile int bar SEC(".data") = 0;
-const volatile int baz SEC(".rodata.baz") = 0;
-const volatile int qux SEC(".rodata.qux") = 0;
-const volatile int quux SEC(".data.quux") = 0;
-const volatile int quuz SEC(".data.quuz") = 0;
-
-long ringbuffer_flags = 0;
-
-SEC("kprobe/sys_mmap")
-int kprobe__sys_mmap(struct pt_regs *ctx)
-{
-    int *process;
-
-    // Reserve space on the ringbuffer for the sample
-    process = bpf_ringbuf_reserve(&events, sizeof(int), ringbuffer_flags);
-    if (!process) {
-        return 1;
-    }
-
-    *process = foo + bar + baz + qux + quux + quuz;
-
-    bpf_ringbuf_submit(process, ringbuffer_flags);
-    return 1;
-}
+const volatile long foo = 0;
+const volatile long bar = 0;
+const volatile long baz = 0;
 
 char LICENSE[] SEC("license") = "GPL";
-


### PR DESCRIPTION
This is a POC of being able to set variables in .rodata, an internal bpf map to set global variables.

In this example it works (can be proven with `sudo bpftool map dump name main.rodata`) but it fails intermittently if the data types of the variables are different (i.e. not all longs or all ints). Still have to get to the bottom of that.

```
[*] sudo bpftool map dump name main.rodata
[{
        "value": {
            ".rodata": [{
                    "foo": 6
                },{
                    "bar": 443
                },{
                    "baz": 333
                }
            ]
        }
    }
]
```

Signed-off-by: grantseltzer <grantseltzer@gmail.com>