### PR TITLE
demo for print panic

### DIFF
--- a/libbpfgo.h
+++ b/libbpfgo.h
@@ -18,6 +18,8 @@ int libbpf_print_fn(enum libbpf_print_level level, const char *format,
   if (level > max_level)
     return 0;
 
+  fprintf(stderr, "[format]: %s\n", format);
+
   // NOTE: va_list args is managed in libbpf caller
   // however, these copies must be matched with va_end() in this function
   va_list exclusivity_check, cgroup_check;

--- a/selftest/map-update/main.go
+++ b/selftest/map-update/main.go
@@ -33,7 +33,7 @@ func resizeMap(module *bpf.Module, name string, size uint32) error {
 }
 
 func main() {
-
+	bpf.SetPrintLevel(bpf.LibbpfPrintLevelDebug)
 	bpfModule, err := bpf.NewModuleFromFile("main.bpf.o")
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)


### PR DESCRIPTION
```
/go_workshop/src/github.com/aquasecurity/libbpfgo/selftest/map-update $
$ sudo ./main-static
[format]: libbpf: loading %s

libbpf: loading main.bpf.o
[format]: libbpf: elf: section(%d) %s, size %ld, link %d, flags %lx, type=%d

fatal error: unexpected signal during runtime execution
[signal SIGSEGV: segmentation violation code=0x1 addr=0x3 pc=0x53ee41]

runtime stack:
runtime.throw({0x5dce1c?, 0x189b5e0?})
	/usr/local/go/src/runtime/panic.go:992 +0x71
runtime.sigpanic()
	/usr/local/go/src/runtime/signal_unix.go:802 +0x3a9

goroutine 1 [syscall]:
runtime.cgocall(0x4a2770, 0xc000047d88)
	/usr/local/go/src/runtime/cgocall.go:157 +0x5c fp=0xc000047d60 sp=0xc000047d28 pc=0x4045bc
github.com/aquasecurity/libbpfgo._C2func_bpf_object__open_file(0x189ae20, 0xc00006a050)
	_cgo_gotypes.go:312 +0x57 fp=0xc000047d88 sp=0xc000047d60 pc=0x49bd57
github.com/aquasecurity/libbpfgo.NewModuleFromFileArgs.func4(0x189ae20?, 0xa?)
	/go_workshop/src/github.com/aquasecurity/libbpfgo/libbpfgo.go:361 +0x50 fp=0xc000047dd0 sp=0xc000047d88 pc=0x49d710
github.com/aquasecurity/libbpfgo.NewModuleFromFileArgs({{0x0, 0x0}, {0x0, 0x0}, {0x0, 0x0}, {0x5d6383, 0xa}, {0x0, 0x0, ...}})
	/go_workshop/src/github.com/aquasecurity/libbpfgo/libbpfgo.go:361 +0x1ac fp=0xc000047e90 sp=0xc000047dd0 pc=0x49d42c
github.com/aquasecurity/libbpfgo.NewModuleFromFile(...)
	/go_workshop/src/github.com/aquasecurity/libbpfgo/libbpfgo.go:261
main.main()
	/go_workshop/src/github.com/aquasecurity/libbpfgo/selftest/map-update/main.go:37 +0x8f fp=0xc000047f80 sp=0xc000047e90 pc=0x4a054f
runtime.main()
	/usr/local/go/src/runtime/proc.go:250 +0x212 fp=0xc000047fe0 sp=0xc000047f80 pc=0x434ff2
runtime.goexit()
	/usr/local/go/src/runtime/asm_amd64.s:1571 +0x1 fp=0xc000047fe8 sp=0xc000047fe0 pc=0x45d9a1
```