### PR TITLE
example with #270

### DIFF
--- a/libbpfgo.h
+++ b/libbpfgo.h
@@ -18,35 +18,36 @@ int libbpf_print_fn(enum libbpf_print_level level, const char *format,
   if (level > max_level)
     return 0;
 
-  // NOTE: va_list args is managed in libbpf caller
-  // however, these copies must be matched with va_end() in this function
-  va_list exclusivity_check, cgroup_check;
-  va_copy(exclusivity_check, args);
-  va_copy(cgroup_check, args);
+  char str[300];
+  va_list check;
+  int ret;
+
+  va_copy(check, args);
+  ret = vsnprintf(str, sizeof(str), format, check);
+  va_end(args);
+
+  // vsnprintf failed for whatever reason. We need
+  // to skip checking.
+  if (ret <= 0) {
+    goto Done;
+  }
 
   // BUG: https://github.com/aquasecurity/tracee/issues/1676
 
-  char *str = va_arg(exclusivity_check, char *);
   if (strstr(str, "Exclusivity flag on") != NULL) {
-    va_end(exclusivity_check);
     return 0;
   }
-  va_end(exclusivity_check);
 
   // AttachCgroupLegacy() will first try AttachCgroup() and it
   // might fail. This is not an error and is the best way of
   // probing for eBPF cgroup attachment link existence.
 
-  str = va_arg(cgroup_check, char *);
   if (strstr(str, "cgroup") != NULL) {
-    str = va_arg(cgroup_check, char *);
-    if (strstr(str, "Invalid argument") != NULL) {
-      va_end(cgroup_check);
+    if (strstr(str, "Invalid argument") != NULL)
       return 0;
-    }
   }
-  va_end(cgroup_check);
 
+Done:
   return vfprintf(stderr, format, args);
 }
 

--- a/selftest/map-update/main.go
+++ b/selftest/map-update/main.go
@@ -33,7 +33,7 @@ func resizeMap(module *bpf.Module, name string, size uint32) error {
 }
 
 func main() {
-
+	bpf.SetPrintLevel(bpf.LibbpfPrintLevelDebug)
 	bpfModule, err := bpf.NewModuleFromFile("main.bpf.o")
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)


### PR DESCRIPTION
```
/go_workshop/src/github.com/aquasecurity/libbpfgo/selftest/map-update: $
$ sudo ./main-static
libbpf: loading main.bpf.o
libbpf: elf: section(3) kprobe/sys_mmap, size 296, link 0, flags 6, type=1
libbpf: sec 'kprobe/sys_mmap': found program 'kprobe__sys_mmap' at insn offset 0 (0 bytes), code size 37 insns (296 bytes)
libbpf: elf: section(4) .relkprobe/sys_mmap, size 64, link 21, flags 0, type=9
libbpf: elf: section(5) .maps, size 56, link 0, flags 3, type=1
libbpf: elf: section(6) license, size 13, link 0, flags 3, type=1
libbpf: license of main.bpf.o is Dual BSD/GPL
libbpf: elf: section(12) .BTF, size 1630, link 0, flags 0, type=1
libbpf: elf: section(14) .BTF.ext, size 256, link 0, flags 0, type=1
libbpf: elf: section(21) .symtab, size 312, link 1, flags 0, type=2
libbpf: looking for externs among 13 symbols...
libbpf: collected 0 externs total
libbpf: map 'tester': at sec_idx 5, offset 0.
libbpf: map 'tester': found type = 1.
libbpf: map 'tester': found key [6], sz = 4.
libbpf: map 'tester': found value [10], sz = 8.
libbpf: map 'tester': found max_entries = 16777216.
libbpf: map 'events': at sec_idx 5, offset 32.
libbpf: map 'events': found type = 4.
libbpf: map 'events': found key_size = 4.
libbpf: map 'events': found value_size = 4.
libbpf: sec '.relkprobe/sys_mmap': collecting relocation for section(3) 'kprobe/sys_mmap'
libbpf: sec '.relkprobe/sys_mmap': relo #0: insn #5 against 'tester'
libbpf: prog 'kprobe__sys_mmap': found map 0 (tester, sec 5, off 0) for insn #5
libbpf: sec '.relkprobe/sys_mmap': relo #1: insn #10 against 'events'
libbpf: prog 'kprobe__sys_mmap': found map 1 (events, sec 5, off 32) for insn #10
libbpf: sec '.relkprobe/sys_mmap': relo #2: insn #21 against 'tester'
libbpf: prog 'kprobe__sys_mmap': found map 0 (tester, sec 5, off 0) for insn #21
libbpf: sec '.relkprobe/sys_mmap': relo #3: insn #27 against 'events'
libbpf: prog 'kprobe__sys_mmap': found map 1 (events, sec 5, off 32) for insn #27
libbpf: map 'tester': created successfully, fd=8
libbpf: map 'events': created successfully, fd=9
/go_workshop/src/github.com/aquasecurity/libbpfgo/selftest/map-update: $
```