### PR TITLE
print debug messages

### DIFF
--- a/selftest/iterators/main.go
+++ b/selftest/iterators/main.go
@@ -20,6 +20,7 @@ const (
 var one = 1
 
 func main() {
+	bpf.SetPrintLevel(bpf.LibbpfPrintLevelDebug)
 
 	bpfModule, err := bpf.NewModuleFromFile("main.bpf.o")
 	if err != nil {


### PR DESCRIPTION
```
$ sudo ./main-static
libbpf: loading main.bpf.o
libbpf: elf: section(3) license, size 13, link 0, flags 3, type=1
libbpf: license of main.bpf.o is Dual BSD/GPL
libbpf: elf: section(4) .maps, size 32, link 0, flags 3, type=1
libbpf: elf: section(9) .BTF, size 470, link 0, flags 0, type=1
libbpf: elf: section(13) .symtab, size 168, link 1, flags 0, type=2
libbpf: looking for externs among 7 symbols...
libbpf: collected 0 externs total
libbpf: map 'numbers': at sec_idx 4, offset 0.
libbpf: map 'numbers': found type = 1.
libbpf: map 'numbers': found key [8], sz = 4.
libbpf: map 'numbers': found value [8], sz = 4.
libbpf: map 'numbers': found max_entries = 5.
libbpf: map 'numbers': created successfully, fd=8
```