### PR TITLE
control spawned processes

### DIFF
--- a/selftest/iter/main.bpf.c
+++ b/selftest/iter/main.bpf.c
@@ -16,7 +16,7 @@ int iter__task(struct bpf_iter__task *ctx)
     if (task == NULL)
         return 0;
 
-    BPF_SEQ_PRINTF(seq, "%d\t%d\t%s\n", task->tgid, task->pid, task->comm);
+    BPF_SEQ_PRINTF(seq, "%d\t%d\t%s\n", task->parent->pid, task->pid, task->comm);
     return 0;
 }
 


### PR DESCRIPTION
make sure that the checked process is the one spawned by the test saving it in a map using its pid as key.

If it's a match (comm, ppid and pid), kill it saving resources.